### PR TITLE
Dont set some keys in a OpenVZ containers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Fixed
 ~~~~~
 
 - Don't set ``net.ipv4.tcp_rfc1337`` and ``net.ipv4.tcp_timestamps`` keys in
-  OpenVZ containers, it isn't allowed. [pedroluislopez]
+  OpenVZ containers, it isn't allowed. [pedroluislopez_]
 
 
 debops.sysctl v0.1.0 - 2016-09-04

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,8 @@ The current role maintainer_ is ypid_.
 Fixed
 ~~~~~
 
-- Don't set 'net.ipv4.tcp_rfc1337' and 'net.ipv4.tcp_timestamps' keys in OpenVZ containers, it isn't allowed.
+- Don't set ``net.ipv4.tcp_rfc1337`` and ``net.ipv4.tcp_timestamps`` keys in
+  OpenVZ containers, it isn't allowed. [pedroluislopez]
 
 
 debops.sysctl v0.1.0 - 2016-09-04

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ The current role maintainer_ is ypid_.
 
 .. _debops.sysctl master: https://github.com/debops/ansible-sysctl/compare/v0.1.0...master
 
+Fixed
+~~~~~
+
+- Don't set 'net.ipv4.tcp_rfc1337' and 'net.ipv4.tcp_timestamps' keys in OpenVZ containers, it isn't allowed.
+
 
 debops.sysctl v0.1.0 - 2016-09-04
 ---------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -172,7 +172,9 @@ sysctl__hardening_map:
   'net.ipv4.tcp_timestamps':
     value: 0
     comment: 'Protect against wrapping sequence numbers at gigabit speeds.'
-    state: '{{ sysctl__hardening_enabled|bool | ternary("present", "absent") }}'
+    state: '{{ (sysctl__hardening_enabled|bool and
+                 not (ansible_virtualization_role == "guest" and ansible_virtualization_type == "openvz"))
+                 | ternary("present", "absent") }}'
 
   'net.ipv4.conf.all.arp_ignore':
     value: 1
@@ -189,7 +191,9 @@ sysctl__hardening_map:
   'net.ipv4.tcp_rfc1337':
     value: 1
     comment: 'RFC 1337 fix F1.'
-    state: '{{ sysctl__hardening_enabled|bool | ternary("present", "absent") }}'
+    state: '{{ (sysctl__hardening_enabled|bool and
+                 not (ansible_virtualization_role == "guest" and ansible_virtualization_type == "openvz"))
+                 | ternary("present", "absent") }}'
                                                                    # ]]]
                                                                    # ]]]
 # Custom kernel parameters [[[


### PR DESCRIPTION
Dont set keys 'net.ipv4.tcp_rfc1337' and 'net.ipv4.tcp_timestamps' in a OpenVZ containers