### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,7 @@ Fixed
 
 - Make sure that role works in Ansible ``--check`` mode. [drybjed_]
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 
 debops.sysctl v0.1.0 - 2016-09-04

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Fixed
 
 - Make sure that role works in Ansible ``--check`` mode. [drybjed_]
 
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 debops.sysctl v0.1.0 - 2016-09-04
 ---------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,8 @@ Fixed
 
 - Make sure that role works in Ansible ``--check`` mode. [drybjed_]
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 
 debops.sysctl v0.1.0 - 2016-09-04

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   author: 'Maciej Delmanowski, Robin Schneider'
   description: 'Manage kernel parameters using sysctl'
   license: 'GPL-3.0'
-  min_ansible_version: '2.0.0'
+  min_ansible_version: '2.2.0'
 
   platforms:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
   shell: sysctl --help | grep -E '^\s+\-\-system\s+' || true
   register: sysctl__register_system
   when: sysctl__register_config|changed
-  always_run: True
+  check_mode: no
 
 - name: Apply kernel parameters if they were modified
   command: '{{ "sysctl --system"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
   shell: sysctl --help | grep -E '^\s+\-\-system\s+' || true
   register: sysctl__register_system
   when: sysctl__register_config|changed
-  check_mode: no
+  check_mode: False
 
 - name: Apply kernel parameters if they were modified
   command: '{{ "sysctl --system"


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.