### PR TITLE
Use short sysctl params

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Apply kernel parameters if they were modified
   command: '{{ "sysctl --system"
                if (sysctl__register_system.stdout != "")
-               else ("sysctl --ignore --load " + sysctl__config_file) }}'
+               else ("sysctl -e -p " + sysctl__config_file) }}'
   when: sysctl__register_config|changed
 
 - name: Post hooks


### PR DESCRIPTION
Add compatibility with Busybox (used by Alpine for example), where
`sysctl --ignore --load` does not work but `sysctl -e -p` does.