### PR TITLE
Fix description of icmp_ignore_bogus_error_responses

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -194,7 +194,9 @@ sysctl__hardening_map:
 
   'net.ipv4.icmp_ignore_bogus_error_responses':
     value: 1
-    comment: 'There is no reason to accept bogus error responses from ICMP, so ignore them instead.'
+    comment: |
+      Do not log bogus ICMP error responses.
+      Nobody would want to accept bogus error responses, so we can safely ignore them.
     state: '{{ sysctl__hardening_enabled|bool | ternary("present", "absent") }}'
 
   'net.ipv4.icmp_ratelimit':


### PR DESCRIPTION
There's no way to accept such error responses.  This setting only controls whether you want to allow a misbehaving (neighbouring?) router to generate whiny kernel log messages, or not :).

> There are some routers on the internet and in other places that ignore the standards drawn up in RFC 1122 and sends out bogus responses to broadcast frames. Normally, these violations are logged via the kernel logging facilities, but if we do not want to see these error messages in our logs we may turn this variable on, which will lead to all such error messages being ignored totally. If you live close to such a router, you will save much harddrive space in not logging these messages.

> This variable takes a boolean value as you may understand, and is per default set to 0 or off. If you need or want this option and want to get rid of some annoying error messages in your logs, you may turn this on.